### PR TITLE
Updates to compile with current typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/swagger-jsdoc": "^6.0.0",
     "@types/swagger-ui-express": "^4.1.2",
     "nodemon": "^2.0.7",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.1.3"
+    "ts-node": "^10.0.0",
+    "typescript": "^4.3.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+    "compilerOptions": {
+      "module": "commonjs",
+      "noImplicitAny": false,
+      "removeComments": true,
+      "preserveConstEnums": true,
+      "sourceMap": true
+    },
+    "files": [
+      "core.ts",
+      "sys.ts",
+      "types.ts",
+      "scanner.ts",
+      "parser.ts",
+      "utilities.ts",
+      "binder.ts",
+      "checker.ts",
+      "emitter.ts",
+      "program.ts",
+      "commandLineParser.ts",
+      "tsc.ts",
+      "diagnosticInformationMap.generated.ts"
+    ]
+    }


### PR DESCRIPTION
I had to do these changes in order to get the project to npm run dev.

I included a tsconfig.json I pulled from the web and had to change noImplicitAny: false. 

I had first updated the ts-node and typescript because the project was throwing errors. So the tsconfig.json may be a requirement of the newer versions. 
